### PR TITLE
[FIX] memory leak on service

### DIFF
--- a/service/pubsub/publish.go
+++ b/service/pubsub/publish.go
@@ -12,8 +12,11 @@ import (
 func PublishTopic(ctx context.Context, pubMessage []byte, topicName string) error {
 	client := NewClient()
 	topic := client.Topic(topicName)
-
-	defer topic.Stop()
+	
+	defer func() {
+		topic.Stop()
+		client.Close()
+	}()
 
 	pubRes := topic.Publish(ctx, &pubsub.Message{Data: pubMessage})
 	fmt.Println("Pubsub message : " + string(pubMessage))


### PR DESCRIPTION
Need close client connection on defer function after message already publish to google pub/sub, 
for not having memory leak when using this package